### PR TITLE
Change systemctl start to enable, add postgres ROLE

### DIFF
--- a/Linux/README.md
+++ b/Linux/README.md
@@ -222,10 +222,10 @@ Before starting the PostreSQL service, a database must be initialized:
 sudo postgresql-setup --initdb --unit postgresql
 ```
 
-Start a PostgreSQL instance (in the background) like so:
+Start a PostgreSQL instance (in the background) and have it start everytime you log in like so:
 
 ```bash
-sudo systemctl start postgresql
+sudo systemctl enable --now postgresql
 ```
 
 To enter PostgreSQL we will switch our shell user to one named `postgres`, and then we can enter the running PostgreSQL instance.
@@ -242,6 +242,12 @@ If your terminal now looks like it does below, you have succesfully installed Po
 
 ```
 postgres=#
+```
+
+Now we are going at a ROLE in POSTGRES:
+
+```
+CREATE ROLE <your user name> LOGIN;
 ```
 
 To exit out of this environment type


### PR DESCRIPTION
PR changes will alleviate issues that Tango Linux students experienced during week 05 day 1.

Changes include:
1) Change systemctl start postgres to systemctl enable --now postgres.  The --now flag is the same as start and enable causes the postgres service to run on every log in.
2) CREATE ROLE <user name> LOGIN;  added to postgres section.  This will allow users to run psql without having to sudo into postgres user.  It also allows users to have read rights to files in their home directories.  This allows syllabus event "https://github.com/tangoplatoon/sql-basics"  commands to not run into "cannot open directory" issues if the curriculum repo is cloned into a user's HOMEDIR. 